### PR TITLE
Tweedie GLM for fecundity

### DIFF
--- a/R/read_lht.R
+++ b/R/read_lht.R
@@ -10,7 +10,7 @@ read_lht <- function(lht_path, resolution_path) {
   # Read trait database
   read_csv(lht_path, show_col_types = FALSE) %>%
     mutate(
-      across(everything(), ~ na_if(.x, -999)),
+      across(where(is.numeric), ~ na_if(.x, -999)),
       inter_birth_interval_y = 1 / litters_or_clutches_per_y,
       adult_body_mass_kg = adult_body_mass_g,
       great_whale = case_when(

--- a/_targets.R
+++ b/_targets.R
@@ -31,7 +31,8 @@ depends <- c(
   "scales",
   "stringr",
   "tibble",
-  "tidyr"
+  "tidyr",
+  "glmmTMB"
 )
 tar_option_set(
   packages = depends,
@@ -147,7 +148,7 @@ list(
   # Subset trait data
   tar_target(
     name = mammal_lht,
-    command = filter(mammal_lht0, tree_name %in% mammal_tr$tip.label)
+    command = mutate(filter(mammal_lht0, tree_name %in% mammal_tr$tip.label), fecundity = pmax(0, litter_or_clutch_size_n - 1))
   ),
   # LHT residuals
   tar_target(


### PR DESCRIPTION
- Added Tweedie GLM for fecundity - 1
- Removed phylogenetic GLS for other predictors, switched to lm - phylogenetic covariance structure is accounted for in PCA, so there's no point in estimating the residual covariance twice
- Switched to Pearson residuals (better than raw residuals for a GLM, and identical to raw residuals for a LM)